### PR TITLE
Upgrade from Amazon Linux 2 to Amazon Linux 2023

### DIFF
--- a/aws/components/account/data_ami.tf
+++ b/aws/components/account/data_ami.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "base_linux" {
   most_recent      = true
-  name_regex       = "^amzn2-ami-hvm-2.0*"
+  name_regex       = "^al2023-ami-2023*"
   owners           = ["137112412989"]
 
   filter {

--- a/aws/components/pss/data_ami.tf
+++ b/aws/components/pss/data_ami.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "base_linux" {
   most_recent      = true
-  name_regex       = "^amzn2-ami-hvm-2.0*"
+  name_regex       = "^al2023-ami-2023*"
   owners           = ["137112412989"]
 
   filter {

--- a/aws/modules/module_ecs_service/ec2_testbox.tf
+++ b/aws/modules/module_ecs_service/ec2_testbox.tf
@@ -2,7 +2,7 @@
 
 data "aws_ami" "base_linux" {
   most_recent      = true
-  name_regex       = "^amzn2-ami-hvm-2.0*"
+  name_regex       = "^al2023-ami-2023*"
   owners           = ["137112412989"]
 
   filter {


### PR DESCRIPTION
Amazon Linux 2 goes out of support in June 2025, Amazon Linux 2023 continues to get security updates until 2028