### PR TITLE
NIAD-3164: Allow MHS to be run with dynamodb persistence_adaptor

### DIFF
--- a/aws/components/base/routes_ptl.tf
+++ b/aws/components/base/routes_ptl.tf
@@ -4,11 +4,11 @@ resource "aws_vpc_endpoint_route_table_association" "s3_vpce_on_ptl_rt" {
   vpc_endpoint_id = aws_vpc_endpoint.s3_endpoint.id
 }
 
-# resource "aws_vpc_endpoint_route_table_association" "dynamodb_vpce_on_ptl_rt" {
-#   count = var.ptl_connected ? 1 : 0
-#   route_table_id = aws_route_table.nhs_ptl[0].id
-#   vpc_endpoint_id = aws_vpc_endpoint.dynamodb_endpoint.id
-# }
+resource "aws_vpc_endpoint_route_table_association" "dynamodb_vpce_on_ptl_rt" {
+  count = var.ptl_connected ? 1 : 0
+  route_table_id = aws_route_table.nhs_ptl[0].id
+  vpc_endpoint_id = aws_vpc_endpoint.dynamodb_endpoint.id
+}
 
 resource "aws_route" "mq_to_ptl_route" {
   count = var.ptl_connected ? 1 : 0

--- a/aws/components/base/sgrules_vpce.tf
+++ b/aws/components/base/sgrules_vpce.tf
@@ -75,11 +75,11 @@ resource "aws_security_group_rule" "core_sg_to_s3_prefix_80" {
 }
 
 # DynamoDB
-# resource "aws_security_group_rule" "core_sg_to_dynamodb_prefix" { 
-#   type      = "egress"
-#   from_port = 443
-#   to_port   = 443
-#   protocol  = "tcp"
-#   security_group_id = aws_security_group.core_sg.id
-#   prefix_list_ids  = [aws_vpc_endpoint.dynamodb_endpoint.prefix_list_id]
-# }
+resource "aws_security_group_rule" "core_sg_to_dynamodb_prefix" { 
+  type      = "egress"
+  from_port = 443
+  to_port   = 443
+  protocol  = "tcp"
+  security_group_id = aws_security_group.core_sg.id
+  prefix_list_ids  = [aws_vpc_endpoint.dynamodb_endpoint.prefix_list_id]
+}

--- a/aws/components/base/vpce.tf
+++ b/aws/components/base/vpce.tf
@@ -1,16 +1,16 @@
 # DynamoDB VPC endpoint
-# resource "aws_vpc_endpoint" "dynamodb_endpoint" {
-#   vpc_id = aws_vpc.base_vpc.id
-#   service_name = "com.amazonaws.${var.region}.dynamodb"
-#   route_table_ids = [
-#     aws_vpc.base_vpc.main_route_table_id,
-#     aws_route_table.private.id
-#   ]
+resource "aws_vpc_endpoint" "dynamodb_endpoint" {
+  vpc_id = aws_vpc.base_vpc.id
+  service_name = "com.amazonaws.${var.region}.dynamodb"
+  route_table_ids = [
+    aws_vpc.base_vpc.main_route_table_id,
+    aws_route_table.private.id
+  ]
 
-#   tags = merge(local.default_tags, {
-#     Name = "${local.resource_prefix}-dynamodb-vpce"
-#   })
-# }
+  tags = merge(local.default_tags, {
+    Name = "${local.resource_prefix}-dynamodb-vpce"
+  })
+}
 
 # ECR DKR VPC endpoint
 resource "aws_vpc_endpoint" "ecr_endpoint" {

--- a/aws/components/mhs/locals_env_variables.tf
+++ b/aws/components/mhs/locals_env_variables.tf
@@ -1,15 +1,17 @@
 locals {
-  persistence_environment_variables = var.mhs_persistence_adaptor == "mongodb" ? [
+  mongo_persistence_environment_variables = [
     {
       name = "MHS_DB_ENDPOINT_URL"
       value = join("&",[data.terraform_remote_state.base.outputs.docdb_cluster_connection_string,"ssl=${data.terraform_remote_state.base.outputs.docdb_tls_enabled}"])
     }
-  ] : [
+  ]
+  dynamodb_persistence_environment_variables = [
     {
       name = "MHS_CLOUD_REGION"
       value = var.region
     }
   ]
+  persistence_environment_variables = var.mhs_persistence_adaptor == "mongodb" ? local.mongo_persistence_environment_variables : local.dynamodb_persistence_environment_variables
 
   # variables common for all three adapters
   environment_variables = concat(concat(var.mhs_environment_variables, local.persistence_environment_variables),[

--- a/aws/components/mhs/locals_env_variables.tf
+++ b/aws/components/mhs/locals_env_variables.tf
@@ -1,6 +1,18 @@
 locals {
+  persistence_environment_variables = var.mhs_persistence_adaptor == "mongodb" ? [
+    {
+      name = "MHS_DB_ENDPOINT_URL"
+      value = join("&",[data.terraform_remote_state.base.outputs.docdb_cluster_connection_string,"ssl=${data.terraform_remote_state.base.outputs.docdb_tls_enabled}"])
+    }
+  ] : [
+    {
+      name = "MHS_CLOUD_REGION"
+      value = var.region
+    }
+  ]
+
   # variables common for all three adapters
-  environment_variables = concat(var.mhs_environment_variables,[
+  environment_variables = concat(concat(var.mhs_environment_variables, local.persistence_environment_variables),[
     {
       name = "MHS_LOG_LEVEL"
       value = var.mhs_log_level
@@ -15,11 +27,7 @@ locals {
     },
     {
       name = "MHS_PERSISTENCE_ADAPTOR"
-      value = "mongodb"
-    },
-    {
-      name = "MHS_DB_ENDPOINT_URL"
-      value = join("&",[data.terraform_remote_state.base.outputs.docdb_cluster_connection_string,"ssl=${data.terraform_remote_state.base.outputs.docdb_tls_enabled}"])
+      value = var.mhs_persistence_adaptor
     },
     {
       name  = "MHS_OUTBOUND_ROUTING_LOOKUP_METHOD"

--- a/aws/components/mhs/variables.tf
+++ b/aws/components/mhs/variables.tf
@@ -101,6 +101,12 @@ variable "mhs_service_launch_type" {
   description = "Type of cluster on which this service will be run, FARGATE or EC2"
 }
 
+variable "mhs_persistence_adaptor" {
+  type = string
+  description = "dynamodb OR mongodb"
+  default = "mongodb"
+}
+
 # variable "mhs_mongo_options" {
 #   type = string
 #   description = "Options for Mongo"


### PR DESCRIPTION
Introduce variable `mhs_persistence_adaptor` to Terraform which configures the adaptor for either Mongo or Dynamo.