### PR TITLE
Remove the profile from AWS Provider config

### DIFF
--- a/aws/components/OneOneOne/terraform.tf
+++ b/aws/components/OneOneOne/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/account/terraform.tf
+++ b/aws/components/account/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 2.62"
   region = var.region
 }

--- a/aws/components/base/terraform.tf
+++ b/aws/components/base/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 2.62"
   region = var.region
 }

--- a/aws/components/fake_mesh/terraform.tf
+++ b/aws/components/fake_mesh/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/gp2gp/terraform.tf
+++ b/aws/components/gp2gp/terraform.tf
@@ -13,6 +13,5 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   region = var.region
 }

--- a/aws/components/lab-results/terraform.tf
+++ b/aws/components/lab-results/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/mhs/terraform.tf
+++ b/aws/components/mhs/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/nhais/terraform.tf
+++ b/aws/components/nhais/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/nhais_responder/terraform.tf
+++ b/aws/components/nhais_responder/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/pss/terraform.tf
+++ b/aws/components/pss/terraform.tf
@@ -7,7 +7,6 @@ terraform {
 
 # Setup AWS provider
 provider "aws" {
-  profile = "default"
   version = "~> 3.37"
   region = var.region
 }


### PR DESCRIPTION
This profile information doesn't do anything, and can break the terraform if being run with auth provided in environment variables.