### PR TITLE
NIAD-3180:  Move terraform deployment job to Github Action

### DIFF
--- a/.github/workflows/terraform-dispatch.yml
+++ b/.github/workflows/terraform-dispatch.yml
@@ -88,7 +88,7 @@ jobs:
       - name: 'Configure AWS Credentials'
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}"
           role-session-name: github_manual_terraform_job
           aws-region: ${{ secrets.AWS_REGION }}
 
@@ -190,7 +190,7 @@ jobs:
         run: |
           cd aws/components/${{ inputs.component }}
           terraform init \
-            -backend-config='bucket=${{ secrets.TF_STATE_BUCKET }}'  \
+            -backend-config='bucket="${{ secrets.TF_STATE_BUCKET }}'  \
             -backend-config='region=${{ secrets.AWS_REGION }}' \
             -backend-config='key=${{ inputs.project }}-${{ inputs.environment }}-${{ inputs.component }}.tfstate' \
             -input=false

--- a/.github/workflows/terraform-dispatch.yml
+++ b/.github/workflows/terraform-dispatch.yml
@@ -1,0 +1,256 @@
+name: Manual terraform job
+on:
+  workflow_dispatch:
+    inputs:
+      project:
+        description: 'Project'
+        default: nia
+        type: choice
+        options:
+          - nia
+
+      environment:
+        description: 'Environment'
+        required: true
+        default: ptl
+        type: choice
+        options:
+          - ptl
+          - account
+
+      action:
+        description: 'Terraform Action'
+        required: true
+        default: plan
+        type: choice
+        options:
+          - Plan
+          - Apply
+          - Plan Destroy
+          - Destroy
+
+      component:
+        description: 'Component'
+        default: gp2gp
+        type: choice
+        options:
+          - base
+          - nhais
+          - OneOneOne
+          - mhs
+          - account
+          - fake_mesh
+          - nhais_responder
+          - gp2gp
+          - lab-results
+          - pss
+
+      build_ids:
+        description: 'Component Build Ids: (i.e gp2gp=PR-855-10-50e5138,gpc-consumer=PR-811-1-20e3452).'
+        type: string
+
+      additional_variables:
+        description: 'Additional terraform variables: (ie variable1=value1,variable2=value2)'
+        type: string
+
+      repository:
+        description: 'Git repository from which terraform will be read (format: [Organisation/Repository])'
+        required: true
+        default: NHSDigital/integration-adaptors-deployment
+        type: string
+
+      branch:
+        description: 'Git branch from which terraform will be taken'
+        required: true
+        default: main
+        type: string
+
+jobs:
+  call-validate-component-build-ids:
+    name: 'Process Build Ids'
+    uses: ./.github/workflows/validate-build-ids.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      component: ${{ inputs.component }}
+      component_build_ids: ${{ inputs.build_ids }}
+    secrets: inherit
+
+  setup-and-run-terraform-job:
+    name: 'Run Terraform Job'
+    runs-on: ubuntu-latest
+    needs: [call-validate-component-build-ids]
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: 'Configure AWS Credentials'
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: github_manual_terraform_job
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: 'Checkout Terraform Repository'
+        uses: actions/checkout@v4.1.7
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.branch }}
+
+      - name: 'Setup Terraform'
+        run: |
+          git clone https://github.com/tfutils/tfenv.git .tfenv
+          cd aws/components/${{ inputs.component }}
+          ../../../.tfenv/bin/tfenv install
+
+      - name: 'Prepare AWS Secrets'
+        id: prepare-aws-secrets
+        run: |
+          global_secret_names=$(aws secretsmanager list-secrets \
+                            --region ${{ secrets.AWS_REGION }} \
+                            --query "SecretList[?starts_with(Name, 'nia-global')].Name" \
+                            --output text)
+          
+          environment_secret_names=$(aws secretsmanager list-secrets \
+                            --region ${{ secrets.AWS_REGION }} \
+                            --query "SecretList[?starts_with(Name, 'nia-${{ inputs.environment }}')].Name" \
+                            --output text)
+          
+          combined_secret_names=($global_secret_names $environment_secret_names)
+          
+          secrets_json=$(echo '{}' | jq '.')
+          
+          for secret_name in "${combined_secret_names[@]}"; do
+            raw_secret_value=$(aws secretsmanager get-secret-value \
+                                --region ${{ secrets.AWS_REGION }} \
+                                --secret-id ${secret_name} \
+                                --query SecretString --output text)
+          
+            if [[ "$secret_name" == *"-kvp" ]]; then
+              echo "Processing -kvp secret: $secret_name"
+          
+              # Parse the secret value as JSON and extract each key-value pair
+              kvp_map=$(echo "$raw_secret_value" | jq -r 'to_entries | map("\(.key)=\(.value | @sh)") | .[]')
+          
+              for kvp in $kvp_map; do
+                key=$(echo "$kvp" | cut -d'=' -f1)
+                value=$(echo "$kvp" | cut -d'=' -f2-)
+                if [[ -n "$key" && -n "$value" ]]; then
+                  echo "::add-mask::$value"
+                  secrets_json=$(echo "$secrets_json" | jq -c --arg key "$key" --arg value "$value" '.[$key] = $value')
+                fi
+              done
+            else
+              echo "::add-mask::$raw_secret_value"
+              secrets_json=$(echo "$secrets_json" | jq -c --arg key "$secret_name" --arg value "$raw_secret_value" '.[$key] = $value')
+            fi
+          done
+          
+          echo "aws_secrets=$secrets_json" >> $GITHUB_OUTPUT
+
+      - name: 'Prepare Additional Variables'
+        id: prepare-additional-variables
+        run: |
+          echo "Additional Variables: ${{ inputs.additional_variables }}"
+          additional_variables_json=$(echo '{}' | jq '.')
+          
+          IFS=',' read -ra pairs <<< "${{ inputs.additional_variables }}"
+          for pair in "${pairs[@]}"; do
+            IFS='=' read -r variable value <<< "$pair"
+              echo "::add-mask::$variable"
+              additional_variables_json=$(echo "$additional_variables_json" | jq -c --arg key "$variable" --arg value "$value" '.[$key] = ($value | fromjson? // $value)')
+          done
+          
+          echo "additional_variables=$additional_variables_json" >> $GITHUB_OUTPUT
+
+      - name: 'Create Terraform Variables File'
+        id: create-terraform-variables-file
+        run: |
+          terraform_vars_file_content_json=$(jq -c -n \
+            --argjson aws_secrets '${{ steps.prepare-aws-secrets.outputs.aws_secrets }}' \
+            --argjson build_ids '${{ needs.call-validate-component-build-ids.outputs.validated_build_ids }}' \
+            --argjson additional_variables '${{ steps.prepare-additional-variables.outputs.additional_variables }}' \
+              '$aws_secrets + $build_ids + $additional_variables')
+          
+          echo "$terraform_vars_file_content_json" | jq -r '
+                  to_entries | .[] |
+                  if (.value | type == "string") then
+                    if ((.value | startswith("[") and endswith("]"))) then
+                      "\(.key) = \(.value)"
+                    else
+                      "\(.key) = \"\(.value)\""
+                    end
+                  else
+                    "\(.key) = \(.value | tojson)"
+                  end
+                ' > aws/etc/secrets.tfvars
+
+      - name: 'Run Terraform: Init'
+        run: |
+          cd aws/components/${{ inputs.component }}
+          terraform init \
+            -backend-config='bucket=${{ secrets.TF_STATE_BUCKET }}'  \
+            -backend-config='region=${{ secrets.AWS_REGION }}' \
+            -backend-config='key=${{ inputs.project }}-${{ inputs.environment }}-${{ inputs.component }}.tfstate' \
+            -input=false
+
+      - name: 'Run Terraform: Plan'
+        run: |
+          cd 'aws/components/${{ inputs.component }}'
+          terraform plan \
+            -var region=${{ secrets.AWS_REGION }} \
+            -var project=${{ inputs.project }} \
+            -var environment=${{ inputs.environment }} \
+            -var tf_state_bucket=${{ secrets.TF_STATE_BUCKET }} \
+            -var-file='../../etc/global.tfvars' \
+            -var-file='../../etc/${{ secrets.AWS_REGION }}_${{ inputs.environment }}.tfvars' \
+            -var-file='../../etc/secrets.tfvars' \
+            -input=false
+
+      - name: 'Run Terraform: Validate'
+        run: |
+          cd 'aws/components/${{ inputs.component }}'
+          terraform validate
+
+      - name: 'Run Terraform: Apply'
+        if: inputs.action == 'Apply'
+        run: |
+          cd 'aws/components/${{ inputs.component }}'
+          terraform apply \
+            -var region=${{ secrets.AWS_REGION }} \
+            -var project=${{ inputs.project }} \
+            -var environment=${{ inputs.environment }} \
+            -var tf_state_bucket=${{ secrets.TF_STATE_BUCKET }} \
+            -var-file='../../etc/global.tfvars' \
+            -var-file='../../etc/${{ secrets.AWS_REGION }}_${{ inputs.environment }}.tfvars' \
+            -var-file='../../etc/secrets.tfvars' \
+            -auto-approve
+
+      - name: 'Run Terraform: Plan Destroy'
+        if: inputs.action == 'Plan Destroy'
+        run: |
+          cd 'aws/components/${{ inputs.component }}'
+          terraform plan -destroy \
+            -var region=${{ secrets.AWS_REGION }} \
+            -var project=${{ inputs.project }} \
+            -var environment=${{ inputs.environment }} \
+            -var tf_state_bucket=${{ secrets.TF_STATE_BUCKET }} \
+            -var-file='../../etc/global.tfvars' \
+            -var-file='../../etc/${{ secrets.AWS_REGION }}_${{ inputs.environment }}.tfvars' \
+            -var-file='../../etc/secrets.tfvars' \
+            -auto-approve
+
+      - name: 'Run Terraform: Destroy'
+        if: inputs.action == 'Destroy'
+        run: |
+          cd 'aws/components/${{ inputs.component }}'
+          terraform destroy \
+            -var region=${{ secrets.AWS_REGION }} \
+            -var project=${{ inputs.project }} \
+            -var environment=${{ inputs.environment }} \
+            -var tf_state_bucket=${{ secrets.TF_STATE_BUCKET }} \
+            -var-file='../../etc/global.tfvars' \
+            -var-file='../../etc/${{ secrets.AWS_REGION }}_${{ inputs.environment }}.tfvars' \
+            -var-file='../../etc/secrets.tfvars' \
+            -auto-approve

--- a/.github/workflows/terraform-dispatch.yml
+++ b/.github/workflows/terraform-dispatch.yml
@@ -46,11 +46,11 @@ on:
           - pss
 
       build_ids:
-        description: 'Component Build Ids: (i.e gp2gp=PR-855-10-50e5138,gpc-consumer=PR-811-1-20e3452).'
+        description: 'Component Build Ids: (i.e. gp2gp=PR-855-10-50e5138,gpc-consumer=PR-811-1-20e3452).'
         type: string
 
       additional_variables:
-        description: 'Additional terraform variables: (ie variable1=value1,variable2=value2)'
+        description: 'Additional terraform variables: (i.e. variable1=value1,variable2=value2)'
         type: string
 
       repository:

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -1,0 +1,142 @@
+name: Retrieve and Validate Build Ids
+
+on:
+  workflow_call:
+    inputs:
+      component:
+        description: Application Component
+        required: true
+        type: string
+      component_build_ids:
+        description: 'Component Build Ids: (i.e gp2gp=PR-855-10-50e5138,gpcc=PR-811-1-20e3452)'
+        required: false
+        type: string
+    outputs:
+      validated_build_ids:
+        description: The validated build ids as JSON
+        value: ${{ jobs.validate-build-ids.outputs.validated_build_ids }}
+
+jobs:
+  validate-build-ids:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      validated_build_ids: ${{ steps.validate.outputs.validated_build_ids }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: github_manual_terraform_job
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Retrieve and Validate component build ids
+        id: validate
+        run: |
+          
+          # Parse the input string into an associative array as 'build_ids_map'
+          declare -A build_ids_map
+          IFS=',' read -ra pairs <<< "${{ inputs.component_build_ids }}"
+          for pair in "${pairs[@]}"; do
+            IFS='=' read -r component build_id <<< "$pair"
+            build_ids_map["$component"]="$build_id"
+          done
+
+          # Initialize JSON output as 'validated_build_id_json'
+          validated_build_ids_json=$(echo '{}' | jq '.')
+
+          input_component=${{ inputs.component }}
+          echo "Processing build ids for '$input_component'..." 
+          
+          # Check if the specified component exists in the component_build_ids    
+          if [[ -z "${build_ids_map[$input_component]}" ]]; then
+
+            # get "main" branch for repository as 'primary_branch'
+            if [ "$input_component" = "nhais" ]; then
+              primary_branch="develop"
+            elif [ "$input_component" = "111" ]; then
+              primary_branch="master"
+            elif [ "$input_component" = "nhais-fake-responder" ]; then
+              primary_branch="origin-develop"
+            else
+              primary_branch="main"
+            fi
+          
+            echo "Component '$input_component' not found in provided build ids."
+            echo "Retrieving latest build tag from '$primary_branch' branch..."      
+          
+            latest_tag=$(aws ecr describe-images \
+              --repository-name "$input_component" \
+              --region "${{ secrets.AWS_REGION }}" \
+              --query "sort_by(imageDetails[?starts_with(imageTags[0], \`$primary_branch\`)], &imagePushedAt)[-1].imageTags[0]" \
+              --output text | head -n 1)
+
+            # format the latest tag to ensure only the first build tag is used
+            latest_tag=$(echo "$latest_tag" | tr -d '\n' | awk '{print $1}')
+
+            if [[ "$latest_tag" == "None" || -z "$latest_tag" ]]; then
+              echo "Error: No builds found on '$primary_branch' branch for component '$input_component'."
+              exit 1
+            else
+              validated_build_ids_json=$(echo "$validated_build_ids_json" \
+                                          | jq -c --arg key "${input_component}_build_id" \
+                                          --arg value "$latest_tag" \
+                                          '.[$key] = $value')
+          
+              echo "Found latest build tag for '$input_component': '$latest_tag'"
+            fi
+          fi
+          
+          if [[ "$input_component"=="gp2gp" && -z "${build_ids_map[gpc-consumer]}" ]]; then
+            echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
+            echo "Retrieving latest build tag for 'gpc-consumer'..."
+          
+            latest_tag=$(aws ecr describe-images \
+              --repository-name "gpc-consumer" \
+              --region "${{ secrets.AWS_REGION }}" \
+              --query 'sort_by(imageDetails[?starts_with(imageTags[0], `main`)], &imagePushedAt)[-1].imageTags[0]' \
+              --output text | head -n 1)
+
+            # format the latest tag to ensure only the first build tag is used
+            latest_tag=$(echo "$latest_tag" | tr -d '\n' | awk '{print $1}')
+
+            if [[ "$latest_tag" == "None" || -z "$latest_tag" ]]; then
+              echo "Error: No builds found on 'main' branch for component 'gpc-consumer'."
+              exit 1
+            else
+              validated_build_ids_json=$(echo "$validated_build_ids_json" \
+                                          | jq -c --arg key "gpc-consumer_build_id" \
+                                          --arg value "$latest_tag" \
+                                          '.[$key] = $value')
+          
+              echo "Found latest build tag for 'gpc-consumer': '$latest_tag'."
+            fi
+          fi
+
+          # Check existence of each image build_id in AWS ECR
+          for component in "${!build_ids_map[@]}"; do
+            build_id="${build_ids_map[$component]}"
+            echo "Validating $component with build tag: $build_id"
+
+            # Check if the image build_id exists in the ECR repository
+            result=$(aws ecr describe-images \
+              --repository-name "$component" \
+              --region "${{ secrets.AWS_REGION }}" \
+              --query "imageDetails[?imageTags && contains(imageTags, '$build_id')]" \
+              --output json)
+
+            if [[ "$result" == "[]" ]]; then
+              echo "Error: Build tag '$build_id' does not exist for component '$component'."
+              exit 1
+            else
+              echo "Found build tag for component '$component': '$build_id'."
+              validated_build_ids_json=$(echo "$validated_build_ids_json" \
+                                          | jq -c --arg key "${component}_build_id" \
+                                          --arg value "$build_id" \
+                                          '.[$key] = $value')
+            fi
+          done
+
+          echo "validated_build_ids=$validated_build_ids_json" >> $GITHUB_OUTPUT

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-to-assume: "arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}"
           role-session-name: github_manual_terraform_job
           aws-region: ${{ secrets.AWS_REGION }}
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Integration Adaptors Deployment
+
+This repository contains the deployment terraform files for both AWS and Azure, for the following components:
+
+* Base
+* NHAIS
+* 111
+* MHS
+* Account
+* Fake Mesh
+* NHAIS Responder
+* GP2GP
+* Lab Results
+* PSS
+
+## Deploying Components
+
+Components Can be deployed using the GitHub action: [Manual Terraform Job](https://github.com/MartinWheelerMT/test-workflow-dispatch/actions/workflows/terraform-dispatch.yml)
+
+Clicking `Run Workflow` will provide a number of configurable parameters to use for the deployment.
+These will be detailed below:
+* `Use Workflow From` - If a change to a GitHub action has been made on a separate branch, then this can be selected 
+here to run that version of the action.
+* `Project` - Currently only contains one value and defaults to `ptl`.
+* `Terraform Action` - The terraform action you wish to complete with this deployment (i.e. `Plan`, `Apply`).
+* `Component` - The component you wish to deploy (i.e. `gp2gp`, `pss`).
+* `Component Build Ids` (Optional) - If you wish to provide a specific build ids for the deployment, these should be
+included here, in the format (<component>=<build id>). Each build id should be separated by a single `,` and spaces
+should not be used.  For example, if you wanted to deploy the `gp2gp` adaptor with a build id of `PR-718-10-3d333bf`,
+and with a `gpc-consumer` with a build id of `PR-122-2-c86dc42`, then this input would be populated with
+`gp2gp=PR-718-10-3d333bf,gpc-consumer=PR-122-2-c86dc42`.
+*`Additional Terraform Variables` (Optional) - If you wish to provide additional variable for the deployment, then
+these are included here in the format (<name>=<value>). Each variable is separated by a single `,` and spaces should
+not be used. For example, if you wanted to enable the redactions when deploying the `gp2gp` adaptor them you should
+populate the input with `gp2gp_redactions_enabled=true`.
+* `Git Repository from which terraform will be read` - Enables you to change the repository used for the terraform
+repository.  This defaults to the current repository and should not need to be changed under most circumstances.
+* `Git Branch from which terraform will be taken` - Enables the selection of the branch within the above repository that 
+terraform will be taken from.  This defaults to the `main` branch and will not need to be changed under most 
+circumstances.


### PR DESCRIPTION
What

A new GitHub action has been added to allow a deployment from the terraform to take place based on the provided variables.
Added a README.md to explain the parameters provided for the new action.

Why

Following a Jenkins outage, it was decided it would be preferable to see which jobs we could move from Jenkins to Github Actions.  The new workflow should be able to run with the following configurations:

* Be able to select which component to deploy.
* Be able to select whether it is a Terraform plan, a Terraform apply, or a Terraform Destroy.
* Be able to build the Terraform stored at a specific branch/commit.
* Be able to select non-default Terraform variables (e.g. mhs_build_id=blah_blah_blah)

Move the terraform dispatch job from Jenkins to Github