### PR TITLE
Remove superfluous quotation mark

### DIFF
--- a/.github/workflows/terraform-dispatch.yml
+++ b/.github/workflows/terraform-dispatch.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           cd aws/components/${{ inputs.component }}
           terraform init \
-            -backend-config='bucket="${{ secrets.TF_STATE_BUCKET }}'  \
+            -backend-config='bucket=${{ secrets.TF_STATE_BUCKET }}'  \
             -backend-config='region=${{ secrets.AWS_REGION }}' \
             -backend-config='key=${{ inputs.project }}-${{ inputs.environment }}-${{ inputs.component }}.tfstate' \
             -input=false


### PR DESCRIPTION
This quotation mark isn't necessary given the bucket name won't have any spaces inside it as per S3 rules.