### PR TITLE
Switch default for our GP2GP Redactions feature flag to true

### DIFF
--- a/aws/components/gp2gp/variables.tf
+++ b/aws/components/gp2gp/variables.tf
@@ -282,7 +282,7 @@ variable gp2gp_gpc_override_from_asid {
 variable gp2gp_redactions_enabled {
   type = bool
   description = "Toggle redactions support"
-  default = false
+  default = true
 }
 
 # Variables related to PTL connectivity


### PR DESCRIPTION
This will make testing easier, as it's easy to forget to turn it on.