### PR TITLE
Reduce the number of 111 instances in PTL

### DIFF
--- a/aws/etc/eu-west-2_ptl.tfvars
+++ b/aws/etc/eu-west-2_ptl.tfvars
@@ -43,9 +43,9 @@ create_testbox = false
 
 # Settings for "OneOneOne" component
 # Name changed to "OneOneOne" from "111" because of problems with some Terraform names starting with number
-OneOneOne_service_minimal_count = 2
-OneOneOne_service_desired_count = 2
-OneOneOne_service_maximal_count = 4
+OneOneOne_service_minimal_count = 1
+OneOneOne_service_desired_count = 1
+OneOneOne_service_maximal_count = 2
 OneOneOne_service_target_request_count = 1200
 OneOneOne_service_container_port = 8080
 OneOneOne_service_launch_type = "FARGATE"


### PR DESCRIPTION
Seems unnecessarily expensive to have multiple instances for our test enviroment.