### PR TITLE
Add CPU / Memory configuration variables for GP2GP, GPCC and Wiremock modules

### DIFF
--- a/aws/components/gp2gp/module_ecs_service.tf
+++ b/aws/components/gp2gp/module_ecs_service.tf
@@ -7,8 +7,8 @@ module "gp2gp_ecs_service" {
   region          = var.region
   module_instance = "gp2gp_ecs"
   default_tags    = local.default_tags
-  memory_units    = var.gp2gp_memory_units
   cpu_units       = var.gp2gp_cpu_units
+  memory_units    = var.gp2gp_memory_units
 
   availability_zones = local.availability_zones
 

--- a/aws/components/gp2gp/module_ecs_service.tf
+++ b/aws/components/gp2gp/module_ecs_service.tf
@@ -7,6 +7,8 @@ module "gp2gp_ecs_service" {
   region          = var.region
   module_instance = "gp2gp_ecs"
   default_tags    = local.default_tags
+  memory_units    = var.gp2gp_memory_units
+  cpu_units       = var.gp2gp_cpu_units
 
   availability_zones = local.availability_zones
 

--- a/aws/components/gp2gp/module_gpc-consumer_ecs_service.tf
+++ b/aws/components/gp2gp/module_gpc-consumer_ecs_service.tf
@@ -7,6 +7,8 @@ module "gpc-consumer_ecs_service" {
   region          = var.region
   module_instance = "gpcc_ecs"
   default_tags    = local.gpc-consumer_default_tags
+  cpu_units       = var.gpcc_cpu_units
+  memory_units    = var.gpcc_memory_units
 
   availability_zones = local.availability_zones
 

--- a/aws/components/gp2gp/module_wiremock_ecs_service.tf
+++ b/aws/components/gp2gp/module_wiremock_ecs_service.tf
@@ -8,7 +8,9 @@ module "gp2gp_wiremock_ecs_service" {
   region          = var.region
   module_instance = "gp2gp_wiremock_ecs"
   default_tags    = local.default_tags
-
+  cpu_units       = var.wiremock_cpu_units
+  memory_units    = var.wiremock_memory_units
+  
   availability_zones = local.availability_zones
 
   image_name        = local.wiremock_image_name

--- a/aws/components/gp2gp/variables.tf
+++ b/aws/components/gp2gp/variables.tf
@@ -285,6 +285,42 @@ variable gp2gp_redactions_enabled {
   default = true
 }
 
+variable gp2gp_cpu_units {
+  type = number
+  description = "Set available CPU units  for the GP2GP Service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  default = 2048
+}
+
+variable gp2gp_memory_units {
+  type = number
+  description = "Set available memory units for the GP2GP Service (1024 = 1GB, 2048 = 2GB etc."
+  default = 8192
+}
+
+variable wiremock_cpu_units {
+  type = number
+  description = "Set available CPU units for the wiremock service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  default = 1024
+}
+
+variable wiremock_memory_units {
+  type = number
+  description = "Set available memory units for the wiremock service (1024 = 1GB, 2048 = 2GB etc."
+  default = 4096
+}
+
+variable gpcc_cpu_units {
+  type = number
+  description = "Set available CPU units for the GPCC service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  default = 2048
+}
+
+variable gpcc_memory_units {
+  type = number
+  description = "Set available memory units for the GPCC service (1024 = 1GB, 2048 = 2GB etc."
+  default = 8192
+}
+
 # Variables related to PTL connectivity
 
 variable "ptl_connected" {

--- a/aws/components/gp2gp/variables.tf
+++ b/aws/components/gp2gp/variables.tf
@@ -287,37 +287,37 @@ variable gp2gp_redactions_enabled {
 
 variable gp2gp_cpu_units {
   type = number
-  description = "Set available CPU units  for the GP2GP Service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  description = "Set available CPU units  for the GP2GP Service (1024 = 1 vCPU, 2048 = 2 vCPU etc.)"
   default = 2048
 }
 
 variable gp2gp_memory_units {
   type = number
-  description = "Set available memory units for the GP2GP Service (1024 = 1GB, 2048 = 2GB etc."
+  description = "Set available memory units for the GP2GP Service (1024 = 1GB, 2048 = 2GB etc.)"
   default = 8192
 }
 
 variable wiremock_cpu_units {
   type = number
-  description = "Set available CPU units for the wiremock service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  description = "Set available CPU units for the wiremock service (1024 = 1 vCPU, 2048 = 2 vCPU etc.)"
   default = 1024
 }
 
 variable wiremock_memory_units {
   type = number
-  description = "Set available memory units for the wiremock service (1024 = 1GB, 2048 = 2GB etc."
+  description = "Set available memory units for the wiremock service (1024 = 1GB, 2048 = 2GB etc.)"
   default = 4096
 }
 
 variable gpcc_cpu_units {
   type = number
-  description = "Set available CPU units for the GPCC service (1024 = 1 vCPU, 2048 = 2 vCPU etc."
+  description = "Set available CPU units for the GPCC service (1024 = 1 vCPU, 2048 = 2 vCPU etc.)"
   default = 2048
 }
 
 variable gpcc_memory_units {
   type = number
-  description = "Set available memory units for the GPCC service (1024 = 1GB, 2048 = 2GB etc."
+  description = "Set available memory units for the GPCC service (1024 = 1GB, 2048 = 2GB etc.)"
   default = 8192
 }
 

--- a/aws/modules/module_ecs_service/variables.tf
+++ b/aws/modules/module_ecs_service/variables.tf
@@ -147,13 +147,13 @@ variable "image_name" {
 variable "cpu_units" {
   type = number
   description = "Number of CPU units to assign to containers"
-  default = 1024
+  default = 2048
 }
 
 variable "memory_units" {
   type = number
   description = "Number of Memory units to assign to containers"
-  default = 2048
+  default = 4096
 }
 
 variable "network_mode" {

--- a/aws/modules/module_ecs_service/variables.tf
+++ b/aws/modules/module_ecs_service/variables.tf
@@ -147,13 +147,13 @@ variable "image_name" {
 variable "cpu_units" {
   type = number
   description = "Number of CPU units to assign to containers"
-  default = 2048
+  default = 1024
 }
 
 variable "memory_units" {
   type = number
   description = "Number of Memory units to assign to containers"
-  default = 4096
+  default = 2048
 }
 
 variable "network_mode" {


### PR DESCRIPTION
During the testing of the adaptor when handling large message payloads, It was observed that the GP2GP Adaptor, GPC Consumer and Wiremock services encounter Java Heap memory issues.

During the testing it was identified that the following memory and CPU requirements were required we as follows:

| Module | vCPU | Memory |
|--------|--------|--------|
| GP2GP | 2 | 8GB |
| Wiremock | 1 | 4GB |
| GPC Consumer | 2 | 8GB | 

After a cost / benefit analysis we decided that it would be prudent to use these baselines when deploying the adaptor.

This change introduces variables to control the number of vCPUs and Memory available to those services (specified in units of 1024 (i.e. a value of `2048` for `gp2gp_cpu_units` is equal to 2 vCPUs for the GP2GP service, and likewise a value of `8196` for `gp2gp_memory_units` is equal to 8GB Memory for the G2GP service).
The default values for these variables are set as per the table above.