### PR TITLE
Remove the explicit specification of aws_appautoscaling_target.role_arn

### DIFF
--- a/aws/components/OneOneOne/module_ecs_service.tf
+++ b/aws/components/OneOneOne/module_ecs_service.tf
@@ -36,7 +36,6 @@ module "OneOneOne_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
   
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/OneOneOne/task_scaling_role.tf
+++ b/aws/components/OneOneOne/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/fake_mesh/module_ecs_service.tf
+++ b/aws/components/fake_mesh/module_ecs_service.tf
@@ -36,7 +36,6 @@ module "fake_mesh_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/fake_mesh/task_scaling_role.tf
+++ b/aws/components/fake_mesh/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/gp2gp/module_ecs_service.tf
+++ b/aws/components/gp2gp/module_ecs_service.tf
@@ -38,7 +38,6 @@ module "gp2gp_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/gp2gp/module_ecs_service_mock_mhs.tf
+++ b/aws/components/gp2gp/module_ecs_service_mock_mhs.tf
@@ -36,7 +36,6 @@ module "mock_mhs_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/gp2gp/module_gpc-consumer_ecs_service.tf
+++ b/aws/components/gp2gp/module_gpc-consumer_ecs_service.tf
@@ -36,7 +36,6 @@ module "gpc-consumer_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/gp2gp/module_wiremock_ecs_service.tf
+++ b/aws/components/gp2gp/module_wiremock_ecs_service.tf
@@ -39,7 +39,6 @@ module "gp2gp_wiremock_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/gp2gp/task_scaling_role.tf
+++ b/aws/components/gp2gp/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/lab-results/module_ecs_service.tf
+++ b/aws/components/lab-results/module_ecs_service.tf
@@ -34,7 +34,6 @@ module "lab-results_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/lab-results/task_scaling_role.tf
+++ b/aws/components/lab-results/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/mhs/module_ecs_service_inbound.tf
+++ b/aws/components/mhs/module_ecs_service_inbound.tf
@@ -37,7 +37,6 @@ module "mhs_inbound_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
   
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/mhs/module_ecs_service_outboud.tf
+++ b/aws/components/mhs/module_ecs_service_outboud.tf
@@ -37,7 +37,6 @@ module "mhs_outbound_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
   
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/mhs/module_ecs_service_route.tf
+++ b/aws/components/mhs/module_ecs_service_route.tf
@@ -37,7 +37,6 @@ module "mhs_route_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
   
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/mhs/task_scaling_role.tf
+++ b/aws/components/mhs/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "AWSServiceRoleForApplicationAutoScaling_ECSService"
-}

--- a/aws/components/nhais/module_ecs_service.tf
+++ b/aws/components/nhais/module_ecs_service.tf
@@ -33,7 +33,6 @@ module "nhais_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/nhais/task_scaling_role.tf
+++ b/aws/components/nhais/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/nhais_responder/module_ecs_service.tf
+++ b/aws/components/nhais_responder/module_ecs_service.tf
@@ -33,7 +33,6 @@ module "nhais_responder_ecs_service" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/nhais_responder/task_scaling_role.tf
+++ b/aws/components/nhais_responder/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/components/pss/module_ecs_service_gp2gp_translator.tf
+++ b/aws/components/pss/module_ecs_service_gp2gp_translator.tf
@@ -34,7 +34,6 @@ module "ecs_service_gp2gp_translator" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/pss/module_ecs_service_gpc_api_facade.tf
+++ b/aws/components/pss/module_ecs_service_gpc_api_facade.tf
@@ -35,7 +35,6 @@ module "ecs_service_gpc_api_facade" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/pss/module_ecs_service_mock_mhs.tf
+++ b/aws/components/pss/module_ecs_service_mock_mhs.tf
@@ -37,7 +37,6 @@ module "ecs_service_mock_mhs" {
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn
-  task_scaling_role_arn   = data.aws_iam_role.ecs_autoscale_role.arn
 
   additional_security_groups = [
     data.terraform_remote_state.base.outputs.core_sg_id,

--- a/aws/components/pss/task_scaling_role.tf
+++ b/aws/components/pss/task_scaling_role.tf
@@ -1,3 +1,0 @@
-data "aws_iam_role" "ecs_autoscale_role" {
-  name = "ecsAutoscaleRole"
-}

--- a/aws/modules/module_ecs_service/appautoscaling_target.tf
+++ b/aws/modules/module_ecs_service/appautoscaling_target.tf
@@ -3,7 +3,6 @@ resource "aws_appautoscaling_target" "service_autoscaling_target" {
   max_capacity = var.maximal_count
   min_capacity = var.minimal_count
   resource_id = "service/${aws_ecs_service.ecs_service.cluster}/${aws_ecs_service.ecs_service.name}"
-  role_arn = var.task_scaling_role_arn
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace = "ecs"
 }

--- a/aws/modules/module_ecs_service/variables.tf
+++ b/aws/modules/module_ecs_service/variables.tf
@@ -254,11 +254,6 @@ variable "task_role_arn" {
   description = "ARN of role used by the container itself"
 }
 
-variable "task_scaling_role_arn" {
-  type = string
-  description = "ARN of role used to autoscale the task"
-}
-
 variable "service_target_request_count" {
   type = number
   description = "The target number of requests per minute that an service should handle. The number of services will be autoscaled so each instance handles this number of requests. This value should be tuned based on the results of performance testing."


### PR DESCRIPTION
At the moment, when deploying the Terraform for the PSS module, the aws_appautoscaling_target.service_autoscaling_target always wants to be updated because the role we specify is different to the one which AWS is actually using.

This field is optional, and will be populated automatically by AWS depending on the service being autoscaled.

Because AWS is populating the field for us, this is causing drift between the state file which is what we think the value is/should be, and what the actual value is.

Letting AWS manage this for us prevents this repeated update, and reduces the complexity of our Terraform code.