### PR TITLE
Move provider version constraints into terraform blocks

### DIFF
--- a/aws/components/OneOneOne/terraform.tf
+++ b/aws/components/OneOneOne/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/account/terraform.tf
+++ b/aws/components/account/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.62"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 2.62"
   region = var.region
 }

--- a/aws/components/base/terraform.tf
+++ b/aws/components/base/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.62"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 2.62"
   region = var.region
 }

--- a/aws/components/fake_mesh/terraform.tf
+++ b/aws/components/fake_mesh/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/lab-results/terraform.tf
+++ b/aws/components/lab-results/terraform.tf
@@ -3,11 +3,16 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }
 

--- a/aws/components/mhs/terraform.tf
+++ b/aws/components/mhs/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/nhais/terraform.tf
+++ b/aws/components/nhais/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/nhais_responder/terraform.tf
+++ b/aws/components/nhais_responder/terraform.tf
@@ -3,10 +3,15 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.28"
   region = var.region
 }

--- a/aws/components/pss/terraform.tf
+++ b/aws/components/pss/terraform.tf
@@ -3,11 +3,16 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.37"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.37"
   region = var.region
 }
 


### PR DESCRIPTION
See also:
https://developer.hashicorp.com/terraform/language/providers/requirements

Resolves the warning:
```
Warning: Version constraints inside provider configuration blocks are deprecated
```