### PR TITLE
Upgrade AWS Terraform provider for PSS component

### DIFF
--- a/aws/components/pss/terraform.tf
+++ b/aws/components/pss/terraform.tf
@@ -3,11 +3,16 @@ terraform {
   backend "s3" {
     # Intentionally blank - all parameters provided in command line
   }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.37"
+    }
+  }
 }
 
 # Setup AWS provider
 provider "aws" {
-  version = "~> 3.37"
   region = var.region
 }
 

--- a/aws/components/pss/terraform.tf
+++ b/aws/components/pss/terraform.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.37"
+      version = "~> 4.67.0"
     }
   }
 }


### PR DESCRIPTION
This fixes a defect where the `aws_s3_bucket_lifecycle_configuration` resource keeps getting adding and removed.