### PR TITLE
Remove OVERRIDE_TO/FROM_ASID variables

### DIFF
--- a/aws/components/gp2gp/locals_env_variables.tf
+++ b/aws/components/gp2gp/locals_env_variables.tf
@@ -65,14 +65,6 @@ locals {
       value = var.gp2gp_gpc_override_nhs_number
     },
     {
-      name = "GP2GP_GPC_OVERRIDE_TO_ASID"
-      value = var.gp2gp_gpc_override_to_asid
-    },
-    {
-      name = "GP2GP_GPC_OVERRIDE_FROM_ASID"
-      value = var.gp2gp_gpc_override_from_asid
-    },
-    {
       name = "GP2GP_REDACTIONS_ENABLED"
       value = var.gp2gp_redactions_enabled
     }

--- a/aws/components/gp2gp/variables.tf
+++ b/aws/components/gp2gp/variables.tf
@@ -267,18 +267,6 @@ variable gp2gp_gpc_override_nhs_number {
   default = ""
 }
 
-variable gp2gp_gpc_override_to_asid {
-  type = string
-  description = "Override value to override to aside in GPC requests"
-  default = ""
-}
-
-variable gp2gp_gpc_override_from_asid {
-  type = string
-  description = "Override value to override from aside in GPC requests"
-  default = ""
-}
-
 variable gp2gp_redactions_enabled {
   type = bool
   description = "Toggle redactions support"

--- a/azure/components/gp2gp/kube-gp2gp_deployment.tf
+++ b/azure/components/gp2gp/kube-gp2gp_deployment.tf
@@ -132,16 +132,6 @@ resource "kubernetes_deployment" "gp2gp" {
           }
           
           env {
-            name = "GP2GP_GPC_OVERRIDE_TO_ASID"
-            value = var.gp2gp_gpc_override_to_asid
-          }
-          
-          env {
-            name = "GP2GP_GPC_OVERRIDE_FROM_ASID"
-            value = var.gp2gp_gpc_override_from_asid
-          }
-
-          env {
             name = "GP2GP_GPC_GET_STRUCTURED_ENDPOINT"
             value = var.gp2gp_gpc_get_structured_endpoint
           }

--- a/azure/components/gp2gp/variables.tf
+++ b/azure/components/gp2gp/variables.tf
@@ -91,19 +91,6 @@ variable "gp2gp_gpc_override_nhs_number" {
   default = ""
 }
 
-variable "gp2gp_gpc_override_to_asid" {
-  type = string
-  description = "Override value to override to aside in GPC requests"
-  default = ""
-}
-
-variable "gp2gp_gpc_override_from_asid" {
-  type = string
-  description = "Override value to override from aside in GPC requests"
-  default = ""
-}
-
-
 variable "gp2gp_application_port" {
   type = number
   description = "Port of which the the service should be visible, also the port used by LB if set"

--- a/azure/etc/build1.tfvars
+++ b/azure/etc/build1.tfvars
@@ -39,8 +39,6 @@ gp2gp_application_port = 80
 gp2gp_container_port = 8080
 gp2gp_log_level = "INFO"
 # gp2gp_gpc_override_nhs_number = "9690938622"
-# gp2gp_gpc_override_to_asid = "200000001329"
-# gp2gp_gpc_override_from_asid = "200000001467"
 
 
 #GPC-CONSUMER CONFIGURATION

--- a/azure/etc/ptl.tfvars
+++ b/azure/etc/ptl.tfvars
@@ -44,8 +44,6 @@ gp2gp_application_port = 80
 gp2gp_container_port = 8080
 gp2gp_log_level = "INFO"
 gp2gp_gpc_override_nhs_number = "9690938622"
-gp2gp_gpc_override_to_asid = "200000001329"
-gp2gp_gpc_override_from_asid = "200000001467"
 
 #GPC-CONSUMER CONFIGURATION
 gpc-consumer_image = "nhsdev/nia-gpc-consumer-adaptor:0.2.8"    # 0.1.5 / 0.2.5 / 0.2.8


### PR DESCRIPTION
The latest adaptor releases do not respect these values, so remove to avoid confusion.