### PR TITLE
NIAD-3261: PSS deployment not working

### DIFF
--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,7 +103,7 @@ jobs:
             fi
           fi
           
-          if [[ "$input_component"=="gp2gp" ]] && -[ -z "${build_ids_map[gpc-consumer]}" ]]; then
+          if [[ "$input_component"=="gp2gp" ]] && [[ -z "${build_ids_map[gpc-consumer]}" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -82,7 +82,7 @@ jobs:
             ecr_repo_name=${ecr_repo_map[$input_component]}
           
             latest_tag=$(aws ecr describe-images \
-              --repository-name "$repositoryName" \
+              --repository-name "$ecr_repo_name" \
               --region "${{ secrets.AWS_REGION }}" \
               --query "sort_by(imageDetails[?starts_with(imageTags[0], \`$primary_branch\`)], &imagePushedAt)[-1].imageTags[0]" \
               --output text | head -n 1)

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -41,6 +41,13 @@ jobs:
         if: ${{ inputs.component != 'account' }}
         id: validate
         run: |
+          declare -A ecr_repo_map;
+          ecr_repo_map["OneOneOne"]: "111";
+          ecr_repo_map["nhais"]: "nhais";
+          ecr_repo_map["nhais_responder"]: "nhais-fake-responder";
+          ecr_repo_map["gp2gp"]: "gp2gp";
+          ecr_repo_map["lab-results"]: "lab-results";
+          ecr_repo_map["pss"]: "pss_gp2gp-translator";
           
           # Parse the input string into an associative array as 'build_ids_map'
           declare -A build_ids_map
@@ -69,10 +76,12 @@ jobs:
             fi
           
             echo "Component '$input_component' not found in provided build ids."
-            echo "Retrieving latest build tag from '$primary_branch' branch..."      
+            echo "Retrieving latest build tag from '$primary_branch' branch..." 
+          
+            repositoryName=ecr_repo_map["$input_component"]
           
             latest_tag=$(aws ecr describe-images \
-              --repository-name "$input_component" \
+              --repository-name "$repositoryName" \
               --region "${{ secrets.AWS_REGION }}" \
               --query "sort_by(imageDetails[?starts_with(imageTags[0], \`$primary_branch\`)], &imagePushedAt)[-1].imageTags[0]" \
               --output text | head -n 1)

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,9 +103,9 @@ jobs:
             fi
           fi
           
-          echo "input component is $input_component"
+          echo $input_component
           
-          if [[ "$input_component"=="gp2gp" ]]; then
+          if [ "$input_component"=="gp2gp"]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -41,13 +41,13 @@ jobs:
         if: ${{ inputs.component != 'account' }}
         id: validate
         run: |
-          declare -A ecr_repo_map;
-          ecr_repo_map["OneOneOne"]: "111";
-          ecr_repo_map["nhais"]: "nhais";
-          ecr_repo_map["nhais_responder"]: "nhais-fake-responder";
-          ecr_repo_map["gp2gp"]: "gp2gp";
-          ecr_repo_map["lab-results"]: "lab-results";
-          ecr_repo_map["pss"]: "pss_gp2gp-translator";
+          declare -A ecr_repo_map=(
+            ["OneOneOne"]="111";
+            ["nhais"]="nhais";
+            ["nhais_responder"]="nhais-fake-responder";
+            ["gp2gp"]="gp2gp";
+            ["lab-results"]="lab-results";
+            ["pss"]="pss_gp2gp-translator";
           
           # Parse the input string into an associative array as 'build_ids_map'
           declare -A build_ids_map
@@ -78,7 +78,7 @@ jobs:
             echo "Component '$input_component' not found in provided build ids."
             echo "Retrieving latest build tag from '$primary_branch' branch..." 
           
-            repositoryName=ecr_repo_map["$input_component"]
+            ecr_repo_name=${ecr_repo_map[$input_component]}
           
             latest_tag=$(aws ecr describe-images \
               --repository-name "$repositoryName" \

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,7 +103,7 @@ jobs:
             fi
           fi
           
-          if [[ "$input_component"=="gp2gp" ]] && [[ -z "${build_ids_map[gpc-consumer]}" ]]; then
+          if [[ "$input_component"=="gp2gp" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -42,12 +42,13 @@ jobs:
         id: validate
         run: |
           declare -A ecr_repo_map=(
-            ["OneOneOne"]="111";
-            ["nhais"]="nhais";
-            ["nhais_responder"]="nhais-fake-responder";
-            ["gp2gp"]="gp2gp";
-            ["lab-results"]="lab-results";
-            ["pss"]="pss_gp2gp-translator";
+            ["OneOneOne"]="111"
+            ["nhais"]="nhais"
+            ["nhais_responder"]="nhais-fake-responder"
+            ["gp2gp"]="gp2gp"
+            ["lab-results"]="lab-results"
+            ["pss"]="pss_gp2gp-translator"
+          )
           
           # Parse the input string into an associative array as 'build_ids_map'
           declare -A build_ids_map

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,6 +103,8 @@ jobs:
             fi
           fi
           
+          echo "input component is $input_component"
+          
           if [[ "$input_component"=="gp2gp" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,6 +103,9 @@ jobs:
             fi
           fi
           
+          echo $input_component
+          echo "${build_ids_map[gpc-consumer]}"
+          
           if [[ "$input_component"=="gp2gp" && -z "${build_ids_map[gpc-consumer]}" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -105,7 +105,7 @@ jobs:
           
           echo $input_component
           
-          if [ "$input_component"=="gp2gp"]; then
+          if [ "$input_component" == "gp2gp" ]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,10 +103,7 @@ jobs:
             fi
           fi
           
-          echo $input_component
-          echo "${build_ids_map[gpc-consumer]}"
-          
-          if [[ "$input_component"=="gp2gp" && -z "${build_ids_map[gpc-consumer]}" ]]; then
+          if [[ "$input_component"=="gp2gp" ]] && -[ -z "${build_ids_map[gpc-consumer]}" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           

--- a/.github/workflows/validate-build-ids.yml
+++ b/.github/workflows/validate-build-ids.yml
@@ -103,9 +103,8 @@ jobs:
             fi
           fi
           
-          echo $input_component
           
-          if [ "$input_component" == "gp2gp" ]; then
+          if [[ "$input_component" == "gp2gp" && -z "${build_ids_map[gpc-consumer]}" ]]; then
             echo "Provided component is gp2gp and build tag has been not provided for gpc-consumer".
             echo "Retrieving latest build tag for 'gpc-consumer'..."
           


### PR DESCRIPTION
Currently the deployment scripts do not work when trying to deploy 'pss'.  This is due to a difference in the naming between the build_id tags and the ECR repository names.

An issue was also identified where the gpc_consumer build tag was also being build, even if the component selected was not 'gp2gp'.