### PR TITLE
Add `mhs` to ECR Repository map.

### DIFF
--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -11,6 +11,7 @@ declare -A ECR_REPOSITORY_MAP=(
             ["gp2gp"]="gp2gp"
             ["lab-results"]="lab-results"
             ["pss"]="pss_gp2gp-translator"
+            ["mhs"]="mhs/outbound"
 )
 
 get_primary_branch() {


### PR DESCRIPTION
* `mhs` was missing in the map of inputs to ECR repositories, meaning the MHS Adaptor could not be deployed with the GitHub Action. It uses a default branch of `main` so no further changes should be needed to the script.