### PR TITLE
Add `gpc-consumer` to ECR Repository map.

### DIFF
--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -12,6 +12,7 @@ declare -A ECR_REPOSITORY_MAP=(
             ["lab-results"]="lab-results"
             ["pss"]="pss_gp2gp-translator"
             ["mhs"]="mhs/outbound"
+            ["gpc-consumer"]="gpc-consumer"
 )
 
 get_primary_branch() {


### PR DESCRIPTION
`gpc-consumer` was missing in the map of inputs to ECR repositories, so when deploying GP2GP without specifying a `gpc-consumer` build-id, then an error was thrown reporting that it could not find the repository.

This was fixed by adding the mapping to the repositories map.