### PR TITLE
Add `dummy` value for GPC_CONSUMER_SDS_APIKEY

### DIFF
--- a/aws/components/gp2gp/gpc-consumer-locals_env_variables.tf
+++ b/aws/components/gp2gp/gpc-consumer-locals_env_variables.tf
@@ -17,6 +17,10 @@ locals {
       value = var.gp2gp_create_wiremock ? "http://${module.gp2gp_wiremock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_wiremock_container_port}/spine-directory/" : var.gpc-consumer_sds_url
     },
     {
+      name = "GPC_CONSUMER_SDS_APIKEY"
+      value = "dummy"
+    },
+    {
       name  = "GPC_SUPPLIER_ODS_CODE"
       value = var.gpc-consumer_supplier_ods_code
     },


### PR DESCRIPTION
* Add `dummy` value for GPC_CONSUMER_SDS_APIKEY to ensure  a default value is provided when deploying to ptl int, which will allow the adaptor to start.  This was made clear by the changes to configuration validation made in an earlier commit