### PR TITLE
NIAD-3315: Deployment job does not fail when provided with an invalid buildId

### DIFF
--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -80,18 +80,21 @@ validate_build_id() {
     echo "Validating build ID '$build_id' for component '$component'..." >&2
 
     local exists
-    exists=$(aws ecr describe-images \
+    if exists=$(aws ecr describe-images \
         --repository-name "$repo_name" \
         --region "$aws_region" \
         --image-ids imageTag="$build_id" \
         --query 'imageDetails' \
-        --output json)
+        --output json); then
 
-    if [[ "$exists" == "[]" ]]; then
-        echo "Error: Build tag '$build_id' does not exist for component '$component'." >&2
-        exit 1
+        if [[ "$exists" == "[]" ]]; then
+            echo "Error: Build tag '$build_id' does not exist for component '$component'." >&2
+            exit 1
+        else
+            echo "Build tag '$build_id' for component '$component' is valid." >&2
+        fi
     else
-        echo "Build tag '$build_id' for component '$component' is valid." >&2
+        echo "Error: Build tag '$build_id' could not be retrieved for '$component'." >&2
     fi
 }
 

--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -95,6 +95,7 @@ validate_build_id() {
         fi
     else
         echo "Error: Build tag '$build_id' could not be retrieved for '$component'." >&2
+        exit 1
     fi
 }
 


### PR DESCRIPTION
### What

* Updated script to handle an error being returned by the AWS CLI.  It now also checks `stderr` for any errors when validating the BuildId.
* Add exit code of 1 to else condition so that Github actions is aware that the job failed.

### Why

When providing an invalid BuildId to the Manual Terraform Job on the `Integration Adaptors Deployment` repository, the job does not report an error but instead continues through the rest of the job.

This is misleading as it imply that the requested version of the adaptor has been deployed to the provided environment but instead the currently existing one remains.