### PR TITLE
NIAD-2098 - turned deployment green for 111

### DIFF
--- a/aws/components/OneOneOne/locals_env_variables.tf
+++ b/aws/components/OneOneOne/locals_env_variables.tf
@@ -6,7 +6,7 @@ locals {
     },
     {
       name = "PEM111_AMQP_QUEUE_NAME"
-      value = "pem111_queue"
+      value = var.pem111_ampq_queue_name
     },
     {
       name = "LOG_LEVEL"
@@ -14,7 +14,15 @@ locals {
     },
     {
       name = "PEM111_ITK_ODS_CODE_LIST"
-      value = "EM396"
+      value = var.OneOneOne_itk_ods_code_list
+    },
+    {
+      name = "PEM111_ITK_EXTERNAL_CONFIGURATION_URL"
+      value = var.pem111_itk_external_configuration_url
+    },
+    {
+      name = "PEM111_ITK_DOS_ID_LIST"
+      value = var.OneOneOne_itk_dos_ids_list
     }
   ])
 }

--- a/aws/components/OneOneOne/variables.tf
+++ b/aws/components/OneOneOne/variables.tf
@@ -111,6 +111,32 @@ variable "OneOneOne_environment_variables" {
   default = []
 }
 
+variable "OneOneOne_itk_ods_code_list" {
+  type        = string
+  description = "The list of ODS codes for the OneOneOne application."
+  default     = "EM396,5L399,RSHSO14A,NVE06,FHR04RPX,E88122,E88122002,PS01RPX02"
+}
+
+
+variable "OneOneOne_itk_dos_ids_list" {
+  type        = string
+  description = "The list of dos ids for the OneOneOne application."
+  default     = "26428,2000038407,136753,1340268940,2000072936,161145,159744,2000080724"
+}
+
+
+variable "pem111_itk_external_configuration_url" {
+  type        = string
+  description = "The external configuration URL for the app."
+  default     = ""
+}
+
+variable "pem111_ampq_queue_name" {
+  type        = string
+  description = "The name of the PEM111 queue."
+  default     = "pem111_queue"
+}
+
 variable "OneOneOne_log_level" {
   type = string
   description = "Level of logging for OneOneOne application"
@@ -173,3 +199,4 @@ variable "OneOneOne_use_nginx_proxy" {
   description = "Should an additional container with nginx reverse proxy be deployed"
   default = false
 }
+


### PR DESCRIPTION
This is a bug fix for ticket [NIAD-2098](https://nhse-dsic.atlassian.net/browse/NIAD-2098). The fix involved providing values for certain environment variables to start up the container with no exceptions or time outs.