### PR TITLE
NIAD-3035: upgrading mongodb to 4.2

### DIFF
--- a/aws/components/base/docdb_cluster.tf
+++ b/aws/components/base/docdb_cluster.tf
@@ -1,6 +1,7 @@
 resource "aws_docdb_cluster" "base_db_cluster" {
   cluster_identifier = "${replace(local.resource_prefix,"_","-")}-dbcluster"
   engine                          = "docdb"
+  engine_version                  = "4.2.0"
   master_username                 = var.docdb_master_user
   master_password                 = var.docdb_master_password
   backup_retention_period         = var.docdb_retention_period

--- a/aws/components/base/docdb_parameter_group.tf
+++ b/aws/components/base/docdb_parameter_group.tf
@@ -1,6 +1,6 @@
 resource "aws_docdb_cluster_parameter_group" "base_db_parameters" {
-  name = "${replace(local.resource_prefix,"_","-")}-db-parameters-36"
-  family = "docdb4.0"
+  name = "${replace(local.resource_prefix,"_","-")}-db-parameters-42"
+  family = "docdb4.2"
   description = "Parameter group for MongoDB in env: ${var.environment}"
 
   parameter {
@@ -15,6 +15,6 @@ resource "aws_docdb_cluster_parameter_group" "base_db_parameters" {
   # }
 
   tags = merge(local.default_tags,{
-    Name = "${replace(local.resource_prefix,"_","-")}-db-parameters-36"
+    Name = "${replace(local.resource_prefix,"_","-")}-db-parameters-42"
   })
 }


### PR DESCRIPTION
MongoDB update to ver. 4.2 as Lab results adaptor fails due to the driver's incompatibility