### PR TITLE
Update deployment scripts to use postgres 16

### DIFF
--- a/aws/components/base/postgres_parameter_group.tf
+++ b/aws/components/base/postgres_parameter_group.tf
@@ -1,6 +1,6 @@
 resource "aws_db_parameter_group" "postgres_base_parameter" {
   name   = "${replace(local.resource_prefix,"_","-")}-postgres-parameters"
-  family = "postgres13"
+  family = "postgres16"
 
   /*parameter {
     name  = "ssl_min_protocol_version"

--- a/aws/components/pss/files/pss_testbox.sh
+++ b/aws/components/pss/files/pss_testbox.sh
@@ -2,5 +2,5 @@
 
 echo "STARTING: Installing additional software(s)"
 yum install -y git
-amazon-linux-extras install -y postgresql13 java-openjdk11
+amazon-linux-extras install -y postgresql16 java-openjdk11
 echo "FINISHED: Installing additional software(s)"


### PR DESCRIPTION
* Update `postgres_parameter_group.tf` to use `postgres16` family.
* Update testbox to install postgres16 to allow access to PSQL commands - this isn't strictly necessary but should be kept aligned.