### PR TITLE
NIAD-3468 : Fix issue with GPC Consumer build id not being found

### DIFF
--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -35,12 +35,11 @@ get_latest_tag() {
     local region="$2"
     local branch_prefix="$3"
 
-    echo "RepoName: $repository_name, Region: $region, Prefix: $branch_prefix" >&2
     aws ecr describe-images \
         --repository-name "$repository_name" \
         --region "$region" \
-        --query "sort_by(imageDetails[?starts_with(imageTags[0], \`$branch_prefix\`)], &imagePushedAt)[-1].imageTags[0]" \
-        --output text | awk '{print $1}'
+        --query "sort_by(imageDetails[?imageTags], &imagePushedAt)[*].imageTags[*] | [] | [?starts_with(@, \`$branch_prefix\`)] | [-1]" \
+        --output text
 }
 
 fetch_latest_build_id() {

--- a/.github/scripts/validate-build-ids.sh
+++ b/.github/scripts/validate-build-ids.sh
@@ -35,6 +35,7 @@ get_latest_tag() {
     local region="$2"
     local branch_prefix="$3"
 
+    echo "RepoName: $repository_name, Region: $region, Prefix: $branch_prefix" >&2
     aws ecr describe-images \
         --repository-name "$repository_name" \
         --region "$region" \


### PR DESCRIPTION
### What

* Update JMESPath to filter images in the AWS Query with no tags to prevent an error when untagged images exist.
* Update JMESPath to flatten the image tag array before searching to handle multiple image tags being present.

### Why

When trying to deploy GP2GP Sending adaptor the `validate-build-id` part of the deployment script complains that it can’t find a GPC Consumer adaptor image on `main`, despite it existing in the AWS ECR.

This was due to there being images present without build tags, causing the existing JMESPath to fail.